### PR TITLE
Comment deprecations in the models to make the tests pass

### DIFF
--- a/solidus/core/app/models/spree/order.rb
+++ b/solidus/core/app/models/spree/order.rb
@@ -552,7 +552,7 @@ module Spree
       Spree::PromotionHandler::Shipping.new(self).activate
       recalculate
     end
-    deprecate apply_free_shipping_promotions: :apply_shipping_promotions, deprecator: Spree::Deprecation
+    # deprecate apply_free_shipping_promotions: :apply_shipping_promotions, deprecator: Spree::Deprecation
 
     # Clean shipments and make order back to address state
     #

--- a/solidus/core/app/models/spree/store.rb
+++ b/solidus/core/app/models/spree/store.rb
@@ -28,7 +28,7 @@ module Spree
     scope :by_url, lambda { |url| where("url like ?", "%#{url}%") }
 
     class << self
-      deprecate :by_url, "Spree::Store.by_url is DEPRECATED", deprecator: Spree::Deprecation
+      # deprecate :by_url, "Spree::Store.by_url is DEPRECATED", deprecator: Spree::Deprecation
     end
 
     def available_locales


### PR DESCRIPTION
These deprecations cause `rspec` to fail even before loading the tests:
```
An error occurred while loading ./spec/models/spree/order/address_spec.rb.
Failure/Error: deprecate apply_free_shipping_promotions: :apply_shipping_promotions, deprecator: Spree::Deprecation

NameError:
  undefined method `apply_free_shipping_promotions' for class `#<Class:0x000055c4324a9790>'
# ./app/models/spree/order.rb:555:in `<class:Order>'
# ./app/models/spree/order.rb:24:in `<module:Spree>'
# ./app/models/spree/order.rb:6:in `<top (required)>'
# ./spec/models/spree/order/address_spec.rb:5:in `<top (required)>'

An error occurred while loading ./spec/models/spree/store_spec.rb.
Failure/Error: deprecate :by_url, "Spree::Store.by_url is DEPRECATED", deprecator: Spree::Deprecation

NameError:
  undefined method `Spree::Store.by_url is DEPRECATED' for class `#<Class:0x000055c432cc3c28>'
# ./app/models/spree/store.rb:31:in `singleton class'
# ./app/models/spree/store.rb:30:in `<class:Store>'
# ./app/models/spree/store.rb:11:in `<module:Spree>'
# ./app/models/spree/store.rb:3:in `<top (required)>'
# ./spec/models/spree/store_spec.rb:5:in `<top (required)>'
Run options: include {:focus=>true}

All examples were filtered out; ignoring {:focus=>true}

Randomized with seed 40714


Finished in 0.00045 seconds (files took 3.54 seconds to load)
0 examples, 0 failures, 2 errors occurred outside of examples

Randomized with seed 40714

```
